### PR TITLE
Made YAML editor always use 2-space indent size

### DIFF
--- a/src/app.layout.ts
+++ b/src/app.layout.ts
@@ -62,6 +62,8 @@ function addEditor(name: string, lang: string, isReadOnly: boolean = false, call
         var editor = ace.edit(container.getElement().get(0));
         editor.setTheme("ace/theme/monokai");
         editor.getSession().setMode(`ace/mode/${lang}`);
+        if (lang === 'yaml')
+            editor.setOption('tabSize', 2);
         editor.$blockScrolling = Infinity; // TODO: remove this line after they fix ACE not to throw warning to the console
         editor.setReadOnly(isReadOnly);
         if (callback)


### PR DESCRIPTION
Editing YAML usually requires you to do a good amount of indenting / unindenting for the blocks. Typically it's done by selecting certain lines and pressing "Tab" to indent or "Shift-Tab" to unindent. It even works with the Ace editor you're using, but the indent size is wrong - it uses 4 spaces, while YAML typically uses 2. This should fix that, setting `tabSize` to 2 for all `"yaml"` editors.
